### PR TITLE
fix: fixed the close modal button on postModal commponent

### DIFF
--- a/src/components/PostModal.jsx
+++ b/src/components/PostModal.jsx
@@ -71,6 +71,11 @@ const PostModal = (props) => {
     props.handleClick(e);
   }
 
+  // This function bubble the event between the parent and child of the close modal button
+  const handleClickBubbling = (event) => {
+    reset(event)
+  }
+
   return (
     <>
       { props.showModal === "open" &&
@@ -78,7 +83,7 @@ const PostModal = (props) => {
           <Content>
             <Header>
               <h2>Create a post</h2>
-              <button onClick = {(event) => reset(event)}><AiOutlineCloseCircle /></button>
+              <button onClick={(event) => handleClickBubbling(event)}><AiOutlineCloseCircle onClick={ (event)=>reset(event)} /></button>
             </Header>
             <SharedContent>
               <UserInfo>


### PR DESCRIPTION
**issue**
The click eventHandler to close modal was not bubbling between `button` Tag  and  `AiOutlineCloseCircle` tag thereby  preventing the modal from closing

**Fixed**
Created a function to handle the event bubbling with the Tags

**Preview**
https://user-images.githubusercontent.com/99693487/209589226-ed6389db-a16d-4f4f-a2aa-7b8ac5ca2cb5.mp4

@4-Leafs-Code Please review am open for corrections


